### PR TITLE
Set ce-subject for Kafka partition

### DIFF
--- a/src/main/java/io/aggregator/action/TransactionGeneratorServiceAction.java
+++ b/src/main/java/io/aggregator/action/TransactionGeneratorServiceAction.java
@@ -39,6 +39,8 @@ public class TransactionGeneratorServiceAction extends AbstractTransactionGenera
 
     log.info("generateTransaction: {}", topicTransaction);
 
-    return effects().reply(topicTransaction);
+    var metadata = actionContext().metadata().set("ce-subject", request.getTransactionId());
+    return effects()
+        .reply(topicTransaction, metadata);
   }
 }


### PR DESCRIPTION
* The ce-subject is used for the Kafka message key, and the Kafka
  partition is derived from the message key.
* Otherwise all messages will be in the same partition.